### PR TITLE
Piper/fix inconsistent key name for package meta

### DIFF
--- a/release-lockfile.spec.md
+++ b/release-lockfile.spec.md
@@ -189,13 +189,13 @@ exceed 214 characters in length.
 
 ### Package Meta: `meta`
 
-The `package_meta` field defines a location for metadata about the package
+The `meta` field defines a location for metadata about the package
 which is not integral in nature for package installation, but may be important
 or convenient to have on-hand for other reasons. This field **should** be
-cinluded in all release lockfiles.
+included in all release lockfiles.
 
 * Required: No
-* Key: `package_meta`
+* Key: `meta`
 * Type:  Object (String: *Package Meta* object)
 
 


### PR DESCRIPTION
The spec was inconsistent with the key it used for the Package Meta.

I chose to go with what was present in the JSON schema because it's precise (and I also know that @tcoulter and my implementations are already using that key.