### PR TITLE
Remove top-level additionalProperties restriction

### DIFF
--- a/spec/release-lockfile.spec.json
+++ b/spec/release-lockfile.spec.json
@@ -7,7 +7,6 @@
     "version"
   ],
   "version": "1",
-  "additionalProperties": false,
   "properties": {
     "lockfile_version": {
       "type": "string",


### PR DESCRIPTION
To allow `x-*` options, et al.

https://github.com/ethpm/ethpm-spec/blob/master/release-lockfile.spec.md#document-specification
> The following fields are defined for the release lockfile. Custom fields may be included. Custom fields should be prefixed with x- to prevent name collisions with future versions of the specification.

Raised in
https://gitter.im/ethpm/Lobby?at=58d1b1bd6d7eb18404f0fc01