### PR TITLE
Use content addressed URIs everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Ethereum Packaging Specification
 
 ## Specification
 
-* [Release Lock File](./release-lockfile.spec.md)
+* [Package](./package.spec.md)
 
 
 ## Definitions
@@ -101,11 +101,11 @@ intended to be used as a base contract for other contracts to be inherited
 from.  The package does not define any pre-deployed addresses for the *owned*
 contract.
 
-The smallest Release Lockfile for this package looks like this:
+The smallest Package for this example looks like this:
 
 ```javascript
 {
-  "lockfile_version": "1",
+  "manifest_version": "2",
   "version": "1.0.0",
   "package_name": "owned",
   "sources": {
@@ -114,12 +114,12 @@ The smallest Release Lockfile for this package looks like this:
 }
 ```
 
-A Release Lockfile which includes more than the minimum information would look like this.
+A Package which includes more than the minimum information would look like this.
 
 
 ```javascript
 {
-  "lockfile_version": "1",
+  "manifest_version": "2",
   "version": "1.0.0",
   "package_name": "owned",
   "package_meta": {
@@ -141,9 +141,9 @@ A Release Lockfile which includes more than the minimum information would look l
 }
 ```
 
-This fully fleshed out Release Lockfile is meant to demonstrate various pieces
+This fully fleshed out Package is meant to demonstrate various pieces
 of optional data that can be included.  However, for the remainder of our
-examples we will be using minimalistic lockfiles to keep our examples as
+examples we will be using minimalistic Packages to keep our examples as
 succinct as possible.
 
 
@@ -179,15 +179,15 @@ gets the *exact* dependencies it needs, all dependencies are declared as
 content addressed URIs.  This ensures that when a package manager fetches a
 dependency it always gets the right one.
 
-The IPFS URI for the previous `owned` Release Lockfile turns out to be
+The IPFS URI for the previous `owned` Package turns out to be
 `ipfs://QmXDf2GP67otcF2gjWUxFt4AzFkfwGiuzfexhGuotGTLJH` which is what we will
-use in our `transferable` package to declare the dependency.  The Release
-Lockfile for our package looks like the following.
+use in our `transferable` package to declare the dependency.  The
+Package looks like the following.
 
 
 ```javascript
 {
-  "lockfile_version": "1",
+  "manifest_version": "2",
   "version": "1.0.0",
   "package_name": "transferable",
   "sources": {
@@ -224,20 +224,20 @@ here within the guide but can be found in the
 [`./examples/standard-token/`](./examples/standard-token/) directory within
 this repository.
 
-Since this package includes a contract which may be used as-is, our Release
-Lockfile is going to contain additional information from our previous examples,
+Since this package includes a contract which may be used as-is, our 
+Package is going to contain additional information from our previous examples,
 specifically, the `contract_types` section.  Since we expect people to compile
 this contract theirselves we won't need to include any of the contract
 bytecode, but it will be useful to include the contract ABI and Natspec
-information.  Our lockfile will look something like the following.  The
+information.  Our Package will look something like the following.  The
 contract ABI and NatSpec sections have been truncated to improve legibility.
-The full Release Lockfile can be found
+The full Package can be found
 [here](./examples/standard-token/1.0.0.json)
 
 
 ```javascript
 {
-  "lockfile_version": "1",
+  "manifest_version": "2",
   "version": "1.0.0",
   "package_name": "standard-token",
   "sources": {
@@ -318,14 +318,14 @@ library SafeMathLib {
 ```
 
 This will be our first package which includes the `deployments` section which is the
-location in the Release Lockfile where information about deployed contract
-instances is found.  Lets look at the Release Lockfile for this package.  Some
+location where information about deployed contract
+instances is found.  Lets look at the Package, some
 parts have been truncated for readability but the full file can be found
 [here](./examples/safe-math-lib/1.0.0.json)
 
 ```javascript
 {
-  "lockfile_version": "1",
+  "manifest_version": "2",
   "version": "1.0.0",
   "package_name": "safe-math-lib",
   "sources": {
@@ -398,23 +398,22 @@ contract, and the block hash in which the deploying transaction was mined.
 For our next example we'll be creating a package includes a deployed instance
 of a *contract type* from that comes from a package dependency.  This differs
 from our previous `safe-math-lib` example where our deployment is referencing a
-local contract from the local `contract_types`.  In this package's Release
-Lockfile we will be referencing a `contract_type` from one of the
-`build_dependencies`
+local contract from the local `contract_types`.  In this package
+we will be referencing a `contract_type` from one of the `build_dependencies`
 
 We are going to use the `standard-token` package we created earlier and include
 a deployed version of the `StandardToken` contract.
 
 Our package will be called `piper-coin` and will not contain any source files
 since it merely makes use of the contracts from the `standard-token` package.
-The Release Lockfile is listed below with some sections truncated for improved
-readability.  The full Release Lockfile can be found at
+The Package is listed below with some sections truncated for improved
+readability.  The full Package can be found at
 [`./examples/piper-coin/1.0.0.json`](./examples/piper-coin/1.0.0.json)
 
 
 ```javascript
 {
-  "lockfile_version": "1",
+  "manifest_version": "2",
   "version": "1.0.0",
   "package_name": "piper-coin",
   "deployments": {
@@ -466,14 +465,14 @@ following two solidity source files.
 The full source for these files can be found here:
 [`./examples/escrow/`](./examples/escrow/).
 
-The Release Lockfile is listed below with some sections truncated for improved
-readability.  The full Release Lockfile can be found at
+The Package is listed below with some sections truncated for improved
+readability.  The full Package can be found at
 [`./examples/escrow/1.0.0.json`](./examples/escrow/1.0.0.json)
 
 
 ```javascript
 {
-  "lockfile_version": "1",
+  "manifest_version": "2",
   "version": "1.0.0",
   "package_name": "escrow",
   "sources": {
@@ -511,7 +510,7 @@ readability.  The full Release Lockfile can be found at
 }
 ```
 
-This Release Lockfile is the first one we've seen thus far that include the
+This Package is the first one we've seen thus far that include the
 `link_dependencies` section within one of the *contract instances*.  The
 `runtime_bytecode` value for the `Escrow` contract has been excluded from the
 example above for readability, but the full value is as follows (wrapped to 80
@@ -541,7 +540,7 @@ instance* describe how these *link references* should be filled in.
 The `offset` value specifies the number of characters into the unprefixed
 bytecode where the replacement should begin.  The `value` defines what address
 should be used to replace the *link reference*.  In this case, the `value` is
-referencing the `SafeSendLib` *contract instance* from this release lockfile.
+referencing the `SafeSendLib` *contract instance* from this Package.
 
 
 ### <a id="package-with-deployed-instance-which-links-against-a-dependency-library" /> Package with a contract with link dependencies on a contract from a package dependency
@@ -585,14 +584,14 @@ contract Wallet is owned {
 }
 ```
 
-The Release Lockfile for our `wallet` package can been seen below.  It has been
-trimmed to improve readability.  The full Release Lockfile can be found at
+The Package for our `wallet` package can been seen below.  It has been
+trimmed to improve readability.  The full Package can be found at
 [`./examples/wallet/1.0.0.json`](./examples/wallet/1.0.0.json)
 
 
 ```javascript
 {
-  "lockfile_version": "1",
+  "manifest_version": "2",
   "version": "1.0.0",
   "package_name": "wallet",
   "sources": {
@@ -689,15 +688,15 @@ contract WalletWithSend is Wallet {
 This new `approvedSend` function allows spending an address's provided *allowance* by
 sending it to a specified address.
 
-The Release Lockfile for our `wallet-with-send` package can been seen below.
-It has been trimmed to improve readability.  The full Release Lockfile can be
+The Package for our `wallet-with-send` package can been seen below.
+It has been trimmed to improve readability.  The full Package can be
 found at [`./examples/wallet-with-send/1.0.0.json`](./examples/wallet-with-send/1.0.0.json)
 
 
 ```javascript
 
 {
-  "lockfile_version": "1",
+  "manifest_version": "2",
   "version": "1.0.0",
   "package_name": "wallet-with-send",
   "sources": {
@@ -737,9 +736,9 @@ found at [`./examples/wallet-with-send/1.0.0.json`](./examples/wallet-with-send/
 }
 ```
 
-The important part of this lockfile is the `link_dependencies` section.
+The important part of this Package is the `link_dependencies` section.
 
-```jacascript
+```javascript
 "link_dependencies": [
     {"offset": 764, "value": "wallet:safe-math-lib:SafeMathLib"}
 ]

--- a/README.md
+++ b/README.md
@@ -10,51 +10,6 @@ Ethereum Packaging Specification
 * [Package](./package.spec.md)
 
 
-## Definitions
-
-The following *types* are used within this specification.
-
-
-### Contract Name
-
-A string matching the regular expression `[_a-zA-Z][_a-zA-Z0-9]*`
-
-
-### Package Name
-
-A string matching the regular expression `[a-zA-Z][-_a-zA-Z0-9]*`
-
-
-### IPFS URI
-
-An URI which matches the regular expression `^ipfs:/?/?.*$`
-
-This allows for either one of the following ipfs supported formats:
-
-- `ipfs://Qm...`
-- `ipfs:/Qm...`
-- `ipfs:Qm...`
-
-
-### Chain Definition via BIP122 URI
-
-An URI in the format `blockchain://<chain_id>/block/<block_hash>`
-
-* `chain_id` is the unprefixed genesis hash for the chain.
-* `block_hash` is the hash of a block on the chain.
-
-A chain is considered to match a chain definition if the the genesis block hash
-matches the `chain_id` and the block defined by `block_hash` can be found on
-that chain.  It is possible for multiple chains to match a single URI, in which
-case all chains are considered valid matches
-
-
-## Resources
-
-* https://pad.riseup.net/p/7x3G896a3NLA
-* https://medium.com/@sdboyer/so-you-want-to-write-a-package-manager-4ae9c17d9527
-
-
 ## Use Cases
 
 The following use cases were considered during the creation of this

--- a/examples/escrow/1.0.0.json
+++ b/examples/escrow/1.0.0.json
@@ -1,5 +1,5 @@
 {
-  "lockfile_version": "1",
+  "manifest_version": "2",
   "version": "1.0.0",
   "package_name": "escrow",
   "sources": {

--- a/examples/owned/1.0.0.json
+++ b/examples/owned/1.0.0.json
@@ -1,5 +1,5 @@
 {
-  "lockfile_version": "1",
+  "manifest_version": "2",
   "version": "1.0.0",
   "package_name": "owned",
   "meta": {

--- a/examples/piper-coin/1.0.0.json
+++ b/examples/piper-coin/1.0.0.json
@@ -1,5 +1,5 @@
 {
-  "lockfile_version": "1",
+  "manifest_version": "2",
   "version": "1.0.0",
   "package_name": "piper-coin",
   "deployments": {

--- a/examples/safe-math-lib/1.0.0.json
+++ b/examples/safe-math-lib/1.0.0.json
@@ -1,5 +1,5 @@
 {
-  "lockfile_version": "1",
+  "manifest_version": "2",
   "version": "1.0.0",
   "package_name": "safe-math-lib",
   "sources": {

--- a/examples/standard-token/1.0.0.json
+++ b/examples/standard-token/1.0.0.json
@@ -1,5 +1,5 @@
 {
-  "lockfile_version": "1",
+  "manifest_version": "2",
   "version": "1.0.0",
   "package_name": "standard-token",
   "sources": {

--- a/examples/transferable/1.0.0.json
+++ b/examples/transferable/1.0.0.json
@@ -1,5 +1,5 @@
 {
-  "lockfile_version": "1",
+  "manifest_version": "2",
   "version": "1.0.0",
   "package_name": "transferable",
   "meta": {

--- a/examples/wallet-with-send/1.0.0.json
+++ b/examples/wallet-with-send/1.0.0.json
@@ -1,5 +1,5 @@
 {
-  "lockfile_version": "1",
+  "manifest_version": "2",
   "version": "1.0.0",
   "package_name": "wallet-with-send",
   "sources": {

--- a/examples/wallet/1.0.0.json
+++ b/examples/wallet/1.0.0.json
@@ -1,5 +1,5 @@
 {
-  "lockfile_version": "1",
+  "manifest_version": "2",
   "version": "1.0.0",
   "package_name": "wallet",
   "sources": {

--- a/package.spec.md
+++ b/package.spec.md
@@ -25,6 +25,7 @@ interpreted as described in RFC 2119.
 
 * https://www.ietf.org/rfc/rfc2119.txt
 
+
 ### Custom
 
 #### Prefixed vs Unprefixed
@@ -157,6 +158,8 @@ A string matching the regular expression `[a-zA-Z][-_a-zA-Z0-9]{0,213}`
 
 Any URI which contains a cryptographic hash which can be used to verify the
 integrity of the content found at the URI.
+
+The URI format is defined in RFC3986
 
 It is **recommended** that tools support IPFS and Swarm.
 

--- a/package.spec.md
+++ b/package.spec.md
@@ -1,18 +1,18 @@
-# Release Lockfile Specification
+# Package Specification
 
-This document defines the specification for the **Release Lockfile**.  The
-release lockfile provides metadata about the package and in most cases should
+This document defines the specification for a **Package**.  The
+Package JSON document provides metadata about itself and in most cases should
 provide sufficient information about the packaged contracts and its
 dependencies to do bytecode verification of its contracts.
 
 ## Guiding Principles
 
-The release lockfile specification makes the following assumptions about the
+The Package specification makes the following assumptions about the
 document lifecycle.
 
-1. Release lockfiles are intended to be generated programatically by package management software as part of the release process.
-2. Release lockfiles will be consumed by package managers during tasks like installing package dependencies or building and deploying new releases.
-3. Release lockfiles will typically **not** be stored alongside the source, but rather by package registries *or* referenced by package registries and stored in something akin to IPFS.
+1. Packages are intended to be generated programatically by package management software as part of the release process.
+2. Packages will be consumed by package managers during tasks like installing package dependencies or building and deploying new releases.
+3. Packages will typically **not** be stored alongside the source, but rather by package registries *or* referenced by package registries and stored in something akin to IPFS.
 
 
 ## Keywords
@@ -111,7 +111,7 @@ a projects source files.
 #### Contract Alias
 
 This is a name used to reference a specific *contract type*.  Contract
-aliases **must** be unique within a single release lockfile.
+aliases **must** be unique within a single Package.
 
 The *contract alias* **must** use *one of* the following naming schemes.
 
@@ -134,7 +134,7 @@ contract instances have an address on some specific chain.
 #### Contract Instance Name
 
 A name which refers to a specific *contract instance* on a specific chain from
-the deployments of a single release lockfile.  This name **must** be unique
+the deployments of a single Package.  This name **must** be unique
 across all other *contract instances* for the given chain.  The name must
 conform to the regular expression `[a-zA-Z][a-zA-Z0-9_]*`.
 
@@ -150,8 +150,8 @@ way.
 
 ## Format
 
-The canonical format for the release lockfile JSON document containing a
-single JSON object.  Lockfiles **must** conform to the following serialization rules.
+The canonical format for the Package JSON document containing a
+single JSON object.  Packages **must** conform to the following serialization rules.
 
 * The document **must** be tightly packed, meaning no linebreaks or extra whitespace.
 * The keys in all objects must be sorted alphabetically.
@@ -162,27 +162,27 @@ single JSON object.  Lockfiles **must** conform to the following serialization r
 
 ## Document Specification
 
-The following fields are defined for the release lockfile.  Custom fields may
+The following fields are defined for the Package.  Custom fields may
 be included.  Custom fields **should** be prefixed with `x-` to prevent name
 collisions with future versions of the specification.
 
 
-### Lock File Version: `lockfile_version`
+### EthPM Manifest Version: `manifest_version`
 
 
-The `lockfile_version` field defines the specification version that this
-document conforms to.  Release lockfiles **must** include this field.
+The `manifest_version` field defines the specification version that this
+document conforms to.  Packages **must** include this field.
 
 * Required: Yes
-* Key: `lockfile_version`
+* Key: `manifest_version`
 * Type: String
-* Allowed Values: `1`
+* Allowed Values: `2`
 
 
 ### Package Name: `package_name`
 
 The `package_name` field defines a human readable name for this package.
-Release lockfiles **must** include this field.  Package names **must**
+Packages **must** include this field.  Package names **must**
 begin with a lowercase letter and be comprised of only lowercase letters,
 numeric characters, and the dash character `'-'`.  Package names **must** not
 exceed 214 characters in length.
@@ -198,7 +198,7 @@ exceed 214 characters in length.
 The `meta` field defines a location for metadata about the package
 which is not integral in nature for package installation, but may be important
 or convenient to have on-hand for other reasons. This field **should** be
-included in all release lockfiles.
+included in all Packages.
 
 * Required: No
 * Key: `meta`
@@ -208,7 +208,7 @@ included in all release lockfiles.
 ### Version: `version`
 
 The `version` field declares the version number of this release.  This value
-**must** be included in all release lockfiles.  This value **should** conform
+**must** be included in all Packages.  This value **should** conform
 to the [semver](http://semver.org/) version numbering specification.
 
 * Required: Yes
@@ -238,8 +238,8 @@ Sources are declared in a key/value mapping.
 ### Contract Types: `contract_types`
 
 The `contract_types` field holds the *contract types* which have been included
-in this release.  Release lockfiles **should** only include *contract types*
-which can be found in the source files for this package.  Release lockfiles
+in this release.  Packages **should** only include *contract types*
+which can be found in the source files for this package. Packages 
 **should not** include *contract types* from dependencies.
 
 * Key: `contract_types`
@@ -279,12 +279,12 @@ this project depends on.
 * Type: Object (String: String)
 * Format:
     * Keys **must** be valid package names matching the regular expression `[a-z][-a-z0-9]{0,213}`
-    * Values **must** be valid IPFS URIs which resolve to a valid *Release Lock File*
+    * Values **must** be valid IPFS URIs which resolve to a valid *Package*
 
 
 ## Object Definitions
 
-Definitions for different objects used within the release lockfile.  All
+Definitions for different objects used within the Package.  All
 objects allow custom fields to be included.  Custom fields **should** be
 prefixed with `x-` to prevent name collisions with future versions of the
 specification.
@@ -298,7 +298,7 @@ The *Package Meta* object is defined to have the following key/value pairs.
 #### Authors: `authors`
 
 The `authors` field defines a list of human readable names for the authors of
-this package.  Release lockfiles **may** include this field.
+this package. Packages **may** include this field.
 
 * Required: No
 * Key: `authors`
@@ -310,7 +310,7 @@ this package.  Release lockfiles **may** include this field.
 The `license` field declares the license under which this package is released.
 This value **should** conform to the
 [SPDX](https://en.wikipedia.org/wiki/Software_Package_Data_Exchange) format.
-Release lockfiles **should** include this field.
+Packages **should** include this field.
 
 * Required: No
 * Key: `license`
@@ -320,7 +320,7 @@ Release lockfiles **should** include this field.
 ### Description: `description`
 
 The `description` field provides additional detail that may be relevant for the
-package.  Release lockfiles **may** include this field.
+package. Packages **may** include this field.
 
 * Required: No
 * Key: `description`
@@ -415,23 +415,23 @@ A *Contract Instance* object is defined to have the following key/value pairs.
 
 The `contract_type` field defines the *contract type* for this *contract
 instance*.  This can reference any of the *contract types* included in this
-release lockfile *or* any of the *contract types* found in any of the package
-dependencies from the `build_dependencies` section of the release lockfile.
+Package *or* any of the *contract types* found in any of the package
+dependencies from the `build_dependencies` section of the Package.
 
 * Required: Yes
 * Type: String
 * Format: **must** conform to one of the following formats
 
-To reference a *contract type* from this release lockfile, use the format `<contract-alias>`.
+To reference a *contract type* from this Package, use the format `<contract-alias>`.
 
 * The `<contract-alias>` value **must** be a valid *contract alias*.
-* The value **must** be present in the keys of the `contract_types` section of this release lockfile.
+* The value **must** be present in the keys of the `contract_types` section of this Package.
 
 To reference a *contract type* from a dependency, use the format `<package-name>:<contract-alias>`.
 
-* The `<package-name>` value **must** be present in the keys of the `build_dependencies` of this release lockfile.
+* The `<package-name>` value **must** be present in the keys of the `build_dependencies` of this Package.
 * The `<contract-alias>` value **must** be be a valid *contract alias*
-* The resolved release lockfile for `<package-name>` must contain the `<contract-alias>` value in the keys of the `contract_types` section.
+* The resolved package for `<package-name>` must contain the `<contract-alias>` value in the keys of the `contract_types` section.
 
 
 #### Address `address`
@@ -527,7 +527,7 @@ corresponding bytecode.
 * Type: String
 * Format: One of the following formats.
 
-To reference the address of a *contract instance* from the current release lockfile
+To reference the address of a *contract instance* from the current Package 
 the value should be the name of that *contract instance*.
 
 * This value **must** be a valid *contract instance* name.
@@ -535,16 +535,16 @@ the value should be the name of that *contract instance*.
 * This value **may not** reference the same *contract instance* that this *link value* belongs to.
 
 
-To reference a *contract instance* from a lockfile from somewhere within the
+To reference a *contract instance* from a Package from somewhere within the
 dependency tree the value is constructed as follows.
 
 * Let `[p1, p2, .. pn]` define the path down the dependency tree.
 * Each of `p1, p2, pn` are dependency names.
-* `p1` **must** be present in keys of the `build_dependencies` for the current release lockfile.
-* For every `pn` where `n > 1`, `pn` **must** be present in the keys of the `build_dependencies` of the lockfile for `pn-1`.
+* `p1` **must** be present in keys of the `build_dependencies` for the current Package.
+* For every `pn` where `n > 1`, `pn` **must** be present in the keys of the `build_dependencies` of the package for `pn-1`.
 * The value is represented by the string `<p1>:<p2>:<...>:<pn>:<contract-instance>` where all of `<p1>`, `<p2>`, `<pn>` are valid package names and `<contract-instance>` is a valid contract name.
 * The `<contract-instance>` value **must** be a valid *contract instance* name.
-* Within the release lockfile of the package dependency defined by `<pn>`, all of the following must be satisfiable:
+* Within the Package of the package dependency defined by `<pn>`, all of the following must be satisfiable:
     * There **must** be *exactly* one chain defined under the `deployments` key which matches the chain definition that this *link value* is nested under.
     * The `<contract-instance>` value **must** be present in the keys of the matching chain.
 

--- a/package.spec.md
+++ b/package.spec.md
@@ -151,7 +151,7 @@ way.
 
 ### Package Name
 
-A string matching the regular expression `[a-zA-Z][-_a-zA-Z0-9]{0,213}`
+A string matching the regular expression `[a-zA-Z][-_a-zA-Z0-9]{0,255}`
 
 
 #### Content Addressable URI
@@ -167,6 +167,7 @@ It is **recommended** that tools support IPFS and Swarm.
 #### Chain Definition 
 
 This definition originates from BIP122 URI
+See BIP122 definition [here](https://github.com/bitcoin/bips/blob/master/bip-0122.mediawiki).
 
 An URI in the format `blockchain://<chain_id>/block/<block_hash>`
 

--- a/package.spec.md
+++ b/package.spec.md
@@ -102,7 +102,7 @@ A deployed instance of the `Wallet` contract would be of of type `Wallet`.
 
 The name found in the source code which defines a specific *contract type*.
 These names **must** conform to the regular expression
-`[a-zA-Z][-a-zA-Z0-9_]*`.
+`[a-zA-Z][-a-zA-Z0-9_]{0,255}`
 
 There can be multiple contracts with the same *contract name* in
 a projects source files.
@@ -136,7 +136,7 @@ contract instances have an address on some specific chain.
 A name which refers to a specific *contract instance* on a specific chain from
 the deployments of a single Package.  This name **must** be unique
 across all other *contract instances* for the given chain.  The name must
-conform to the regular expression `[a-zA-Z][a-zA-Z0-9_]*`.
+conform to the regular expression `[a-zA-Z][a-zA-Z0-9_]{0,255}`
 
 In cases where there is a single deployed instance of a given *contract type*
 package managers **should** use the *contract alias* for that *contract type*
@@ -146,6 +146,34 @@ In cases where there are multiple deployed instances of a given *contract type*
 package managers **should** use a name which provides some added semantic
 information as to help differentiate the two deployed instances in a meaningful
 way.
+
+
+### Package Name
+
+A string matching the regular expression `[a-zA-Z][-_a-zA-Z0-9]{0,213}`
+
+
+#### Content Addressable URI
+
+Any URI which contains a cryptographic hash which can be used to verify the
+integrity of the content found at the URI.
+
+It is **recommended** that tools support IPFS and Swarm.
+
+
+#### Chain Definition 
+
+This definition originates from BIP122 URI
+
+An URI in the format `blockchain://<chain_id>/block/<block_hash>`
+
+* `chain_id` is the unprefixed hexidecimal representation of the genesis hash for the chain.
+* `block_hash` is the unprefixed hexidecimal representation of the hash of a block on the chain.
+
+A chain is considered to match a chain definition if the the genesis block hash
+matches the `chain_id` and the block defined by `block_hash` can be found on
+that chain.  It is possible for multiple chains to match a single URI, in which
+case all chains are considered valid matches
 
 
 ## Format
@@ -190,7 +218,7 @@ exceed 214 characters in length.
 * Required: Yes
 * Key: `package_name`
 * Type: String
-* Format: Package names must conform to the following regular expression. `[a-z][-a-z0-9]{0,213}`
+* Format: **must** be a valid package name.
 
 
 ### Package Meta: `meta`
@@ -227,7 +255,7 @@ Sources are declared in a key/value mapping.
 * Values **must** conform to *one of* the following formats.
     * Source string.
         * When the value is a source string the key should be interpreted as a file path.
-    * IPFS URI
+    * Content Addressable URI
         * *If* the resulting document is a directory the key should be interpreted as a directory path.
         * *If* the resulting document is a file the key should be interpreted as a file path.
 
@@ -361,7 +389,7 @@ The `contract_name` field defines *contract name* for this *contract type*.
 
 * Required: If the *contract name* and *contract alias* are not the same.
 * Type: String
-* Format: **must** match the regular expression `[a-zA-Z][a-zA-Z0-9_]*`
+* Format: **must** be a valid contract name.
 
 
 #### Bytecode `bytecode`

--- a/package.spec.md
+++ b/package.spec.md
@@ -255,7 +255,7 @@ Sources are declared in a key/value mapping.
 * Values **must** conform to *one of* the following formats.
     * Source string.
         * When the value is a source string the key should be interpreted as a file path.
-    * Content Addressable URI
+    * Content Addressable URI.
         * *If* the resulting document is a directory the key should be interpreted as a directory path.
         * *If* the resulting document is a file the key should be interpreted as a file path.
 

--- a/release-lockfile.spec.md
+++ b/release-lockfile.spec.md
@@ -150,8 +150,12 @@ way.
 
 ## Format
 
-The canonical format for the release lockfile is a JSON document containing a
-single JSON object.  
+The canonical format for the release lockfile JSON document containing a
+single JSON object.  Lockfiles **must** conform to the following serialization rules.
+
+* The document must be tighly packed, meaning no linebreaks or extra whitespace.
+* The *all* keys in all objects must be sorted alphabetically.
+* The document **must** use utf8 encoding.
 
 
 ## Document Specification

--- a/release-lockfile.spec.md
+++ b/release-lockfile.spec.md
@@ -111,13 +111,13 @@ a projects source files.
 #### Contract Alias
 
 This is a name used to reference a specific *contract type*.  Contract
-aliases **must** be unique within a single release lockfile.  
+aliases **must** be unique within a single release lockfile.
 
 The *contract alias* **must** use *one of* the following naming schemes.
 
 * `<contract-name>`
 * `<contract-name>[<identifier>]`
-    
+
 The `<contract-name>` portion **must** be the same as the *contract name* for
 this *contract type*.
 
@@ -125,7 +125,7 @@ The `[<identifier>]` portion **must** match the regular expression
 `\[[-a-zA-Z0-9]{1,256}\]`.
 
 
-#### Contract Instance 
+#### Contract Instance
 
 A contract instance a specific deployed version of a *contract type*.  All
 contract instances have an address on some specific chain.
@@ -153,9 +153,11 @@ way.
 The canonical format for the release lockfile JSON document containing a
 single JSON object.  Lockfiles **must** conform to the following serialization rules.
 
-* The document must be tighly packed, meaning no linebreaks or extra whitespace.
-* The *all* keys in all objects must be sorted alphabetically.
+* The document **must** be tightly packed, meaning no linebreaks or extra whitespace.
+* The keys in all objects must be sorted alphabetically.
+* Duplicate keys in the same object are invalid.
 * The document **must** use utf8 encoding.
+* The document **must** not have a trailing newline.
 
 
 ## Document Specification
@@ -218,7 +220,7 @@ to the [semver](http://semver.org/) version numbering specification.
 
 The `sources` field defines a source tree that **should** comprise the full
 source tree necessary to recompile the contracts contained in this release.
-Sources are declared in a key/value mapping.  
+Sources are declared in a key/value mapping.
 
 * Keys **must** be relative filesystem paths beginning with a `./`.  Paths **must** resolve to a path that is within the current working directory.
 
@@ -242,7 +244,7 @@ which can be found in the source files for this package.  Release lockfiles
 
 * Key: `contract_types`
 * Type:  Object (String: *Contract Type* Object)
-* Format: 
+* Format:
     * Keys **must** be valid *contract aliases*.
     * Values **must** conform to the *Contract Type* object definition.
 
@@ -260,7 +262,7 @@ defined by the BIP122 URI keys for this object **must** be unique.
 
 * Key: `deployments`
 * Type:  Object (String: Object(String: *Contract Instance* Object))
-* Format: 
+* Format:
     * Keys **must** be valid BIP122 URI chain definitions.
     * Values **must** be objects which conform to the format:
         * Keys **must** be valid *contract instance* names.
@@ -296,7 +298,7 @@ The *Package Meta* object is defined to have the following key/value pairs.
 #### Authors: `authors`
 
 The `authors` field defines a list of human readable names for the authors of
-this package.  Release lockfiles **may** include this field. 
+this package.  Release lockfiles **may** include this field.
 
 * Required: No
 * Key: `authors`
@@ -327,7 +329,7 @@ package.  Release lockfiles **may** include this field.
 
 ### Keywords: `keywords`
 
-The `keywords` field provides relevant keywords related to this package.  
+The `keywords` field provides relevant keywords related to this package.
 
 * Required: No
 * Key: `keywords`
@@ -393,7 +395,7 @@ portion of bytecode for this *contract type*.
 * Required: No
 * Type: Object
 * Format: The Merged *UserDoc* and *DevDoc*
-    * [UserDoc](https://github.com/ethereum/wiki/wiki/Ethereum-Natural-Specification-Format#user-documentation) 
+    * [UserDoc](https://github.com/ethereum/wiki/wiki/Ethereum-Natural-Specification-Format#user-documentation)
     * [DevDoc](https://github.com/ethereum/wiki/wiki/Ethereum-Natural-Specification-Format#developer-documentation)
 
 
@@ -425,10 +427,10 @@ To reference a *contract type* from this release lockfile, use the format `<cont
 * The `<contract-alias>` value **must** be a valid *contract alias*.
 * The value **must** be present in the keys of the `contract_types` section of this release lockfile.
 
-To reference a *contract type* from a dependency, use the format `<package-name>:<contract-alias>`.  
+To reference a *contract type* from a dependency, use the format `<package-name>:<contract-alias>`.
 
-* The `<package-name>` value **must** be present in the keys of the `build_dependencies` of this release lockfile.  
-* The `<contract-alias>` value **must** be be a valid *contract alias* 
+* The `<package-name>` value **must** be present in the keys of the `build_dependencies` of this release lockfile.
+* The `<contract-alias>` value **must** be be a valid *contract alias*
 * The resolved release lockfile for `<package-name>` must contain the `<contract-alias>` value in the keys of the `contract_types` section.
 
 
@@ -512,7 +514,7 @@ representation of the bytecode.
 * Required: Yes
 * Type: Integer
 * Format: The integer **must** conform to all of the following:
-    * be greater than or equal to zero 
+    * be greater than or equal to zero
     * strictly less than the length of the unprefixed hexidecimal representation of the corresponding bytecode.
 
 
@@ -526,7 +528,7 @@ corresponding bytecode.
 * Format: One of the following formats.
 
 To reference the address of a *contract instance* from the current release lockfile
-the value should be the name of that *contract instance*.  
+the value should be the name of that *contract instance*.
 
 * This value **must** be a valid *contract instance* name.
 * The chain definition under which the *contract instance* that this *link value* belongs to must contain this value within its keys.
@@ -552,7 +554,7 @@ will be published as open source packages or that are intended to be used
 outside of a closed system.  Package managers **should** require some form of
 explicit input from the user such as a command line flag like
 `--allow-unverifiable-linking` before linking code with this type of *link
-value*. 
+value*.
 
 
 ### The *Compiler Information* Object
@@ -577,9 +579,9 @@ The `type` field defines which compiler was used in compilation.
 
 #### Version `version`
 
-The `version` field defines the version of the compiler. The field **should** be OS 
+The `version` field defines the version of the compiler. The field **should** be OS
 agnostic (OS not included in the string) and take the form of either the stable version
-in semver format or if built on a nightly should be denoted in the form of 
+in semver format or if built on a nightly should be denoted in the form of
 `<semver>-<commit-hash>` ex: `0.4.8-commit.60cc1668`.
 
 * Required: Yes

--- a/spec/package.spec.json
+++ b/spec/package.spec.json
@@ -37,7 +37,7 @@
               "type": "string"
             },
             {
-              "$ref": "IPFS-URI"
+              "$ref": "#/definitions/ContentURI"
             }
           ]
         }
@@ -71,7 +71,7 @@
       "type": "object",
       "patternProperties": {
         "^[a-z][-a-z0-9]{0,213}$": {
-          "$ref": "#/definitions/IPFS-URI"
+          "$ref": "#/definitions/ContentURI"
         }
       }
     }
@@ -268,11 +268,10 @@
       "type": "string",
       "pattern": "^0x[0-9a-zA-Z]{64}$"
     },
-    "IPFS-URI": {
-      "title": "An IPFS URI",
+    "ContentURI": {
+      "title": "An content addressable URI",
       "type": "string",
-      "format": "uri",
-      "pattern": "^ipfs:/?/?.*$"
+      "format": "uri"
     }
   }
 }

--- a/spec/package.spec.json
+++ b/spec/package.spec.json
@@ -17,7 +17,7 @@
     "package_name": {
       "title": "The name of the package that this release is for",
       "type": "string",
-      "pattern": "^[a-z][-a-z0-9]{0,213}$"
+      "pattern": "^[a-z][-a-z0-9]{0,255}$"
     },
     "meta": {
       "$ref": "#/definitions/PackageMeta"
@@ -70,7 +70,7 @@
       "title": "Build Dependencies",
       "type": "object",
       "patternProperties": {
-        "^[a-z][-a-z0-9]{0,213}$": {
+        "^[a-z][-a-z0-9]{0,255}$": {
           "$ref": "#/definitions/ContentURI"
         }
       }
@@ -153,7 +153,7 @@
         "contract_type": {
           "title": "The contract type of this contract instance",
           "type": "string",
-          "pattern": "^(?:[a-z][-a-z0-9]{0,213}\\:)?[a-zA-Z][-a-zA-Z0-9_]{0,255}(?:\\[[-a-zA-Z0-9]{1,256}\\])?$"
+          "pattern": "^(?:[a-z][-a-z0-9]{0,255}\\:)?[a-zA-Z][-a-zA-Z0-9_]{0,255}(?:\\[[-a-zA-Z0-9]{1,256}\\])?$"
         },
         "address": {
           "$ref": "#/definitions/Address"
@@ -211,7 +211,7 @@
     "PackageContractInstanceName": {
       "title": "The path to a deployed contract instance somewhere down the dependency tree",
       "type": "string",
-      "pattern": "^([a-z][-a-z0-9]{0,213}\\:)+[a-zA-Z][a-zA-Z0-9_]{0,255}$"
+      "pattern": "^([a-z][-a-z0-9]{0,255}\\:)+[a-zA-Z][a-zA-Z0-9_]{0,255}$"
     },
     "CompilerInformation": {
       "title": "Information about the software that was used to compile a contract type or instance",

--- a/spec/package.spec.json
+++ b/spec/package.spec.json
@@ -47,7 +47,7 @@
       "title": "The contract types included in this release",
       "type": "object",
       "patternProperties": {
-        "[a-zA-Z][-a-zA-Z0-9_]*(?:\\[[-a-zA-Z0-9]{1,256}\\])$": {
+        "[a-zA-Z][-a-zA-Z0-9_]{0,255}(?:\\[[-a-zA-Z0-9]{1,256}\\])$": {
           "$ref": "#/definitions/ContractType"
         }
       }
@@ -59,7 +59,7 @@
         "^blockchain\\://[0-9a-zA-Z]{64}/block/[0-9a-zA-Z]{64}$": {
           "type": "object",
           "patternProperties": {
-            "^[a-zA-Z][a-zA-Z0-9_]*$": {
+            "^[a-zA-Z][a-zA-Z0-9_]{0,255}$": {
               "$ref": "#/definitions/ContractInstance"
             }
           }
@@ -120,7 +120,7 @@
         "contract_name": {
           "title": "The name for this contract type as found in the project source code.",
           "type": "string",
-          "pattern": "[a-zA-Z][a-zA-Z0-9_]*"
+          "pattern": "[a-zA-Z][a-zA-Z0-9_]{0,255}"
         },
         "bytecode": {
           "title": "The unlinked '0x' prefixed bytecode for this contract type",
@@ -153,7 +153,7 @@
         "contract_type": {
           "title": "The contract type of this contract instance",
           "type": "string",
-          "pattern": "^(?:[a-z][-a-z0-9]{0,213}\\:)?[a-zA-Z][-a-zA-Z0-9_]*(?:\\[[-a-zA-Z0-9]{1,256}\\])?$"
+          "pattern": "^(?:[a-z][-a-z0-9]{0,213}\\:)?[a-zA-Z][-a-zA-Z0-9_]{0,255}(?:\\[[-a-zA-Z0-9]{1,256}\\])?$"
         },
         "address": {
           "$ref": "#/definitions/Address"
@@ -206,12 +206,12 @@
     "ContractInstanceName": {
       "title": "The name of the deployed contract instance",
       "type": "string",
-      "pattern": "^[a-zA-Z][a-zA-Z0-9_]*$"
+      "pattern": "^[a-zA-Z][a-zA-Z0-9_]{0,255}$"
     },
     "PackageContractInstanceName": {
       "title": "The path to a deployed contract instance somewhere down the dependency tree",
       "type": "string",
-      "pattern": "^([a-z][-a-z0-9]{0,213}\\:)+[a-zA-Z][a-zA-Z0-9_]*$"
+      "pattern": "^([a-z][-a-z0-9]{0,213}\\:)+[a-zA-Z][a-zA-Z0-9_]{0,255}$"
     },
     "CompilerInformation": {
       "title": "Information about the software that was used to compile a contract type or instance",

--- a/spec/package.spec.json
+++ b/spec/package.spec.json
@@ -1,18 +1,18 @@
 {
-  "title": "Release Lock File Specification",
+  "title": "Package Specification",
   "type": "object",
   "required": [
-    "lockfile_version",
+    "manifest_version",
     "package_name",
     "version"
   ],
-  "version": "1",
+  "version": "2",
   "properties": {
-    "lockfile_version": {
+    "manifest_version": {
       "type": "string",
-      "title": "Lock File Version",
-      "default": "1",
-      "enum": ["1"]
+      "title": "EthPM Manifest Version",
+      "default": "2",
+      "enum": ["2"]
     },
     "package_name": {
       "title": "The name of the package that this release is for",

--- a/validate.py
+++ b/validate.py
@@ -2,35 +2,36 @@ import json
 import jsonschema
 
 
-def load_release_lockfile_schema():
-    with open('spec/release-lockfile.spec.json') as schema_file:
+def load_package_schema():
+    with open('spec/package.spec.json') as schema_file:
         schema = json.load(schema_file)
     return schema
 
 
 FILES_TO_VALIDATE = (
-    './examples/owned/1.0.0.json',
-    './examples/transferable/1.0.0.json',
-    './examples/standard-token/1.0.0.json',
-    './examples/safe-math-lib/1.0.0.json',
-    './examples/piper-coin/1.0.0.json',
-    './examples/wallet/1.0.0.json',
     './examples/escrow/1.0.0.json',
+    './examples/owned/1.0.0.json',
+    './examples/piper-coin/1.0.0.json',
+    './examples/safe-math-lib/1.0.0.json',
+    './examples/standard-token/1.0.0.json',
+    './examples/transferable/1.0.0.json',
+    './examples/wallet-with-send/1.0.0.json',
+    './examples/wallet/1.0.0.json',
 )
 
 
-def validate_example_lockfiles():
-    lockfile_schema = load_release_lockfile_schema()
+def validate_example_packages():
+    package_schema = load_package_schema()
     for file_path in FILES_TO_VALIDATE:
-        with open(file_path) as lockfile_file:
+        with open(file_path) as package_file:
             try:
-                lockfile = json.load(lockfile_file)
+                package = json.load(package_file)
             except json.JSONDecodeError as error:
                 raise ValueError("Invalid JSON File: {0}\n{1}".format(file_path, str(error)))
             except Exception as error:
                 raise ValueError("Something is broken: {0}\n{1}".format(file_path, str(error)))
-            jsonschema.validate(lockfile, lockfile_schema)
+            jsonschema.validate(package, package_schema)
 
 
 if __name__ == '__main__':
-    validate_example_lockfiles()
+    validate_example_packages()


### PR DESCRIPTION
Fixes #66 

### What was wrong?

The v1 version of the spec used IPFS URIs everywhere that external content was referenced.  This was overly inflexible.

### How was it fixed

Changed to use a generic definition of a content addressable URI in all places that IPFS URIs were previously specified.

- [x] TODO: update the json-schema accordingly.

![chihuahuaandthechicken_24](https://user-images.githubusercontent.com/824194/32667871-3ce22504-c5f9-11e7-999f-eb7450cc8499.jpg)
