### PR TITLE
add extra spec about serialization format for json document

### DIFF
--- a/release-lockfile.spec.md
+++ b/release-lockfile.spec.md
@@ -150,8 +150,12 @@ way.
 
 ## Format
 
-The canonical format for the release lockfile is a JSON document containing a
-single JSON object.  
+The canonical format for the release lockfile JSON document containing a
+single JSON object.  Lockfiles **must** conform to the following serialization rules.
+
+* The document must be tighly packed, meaning no linebreaks or extra whitespace.
+* The *all* keys in all objects must be sorted alphabetically.
+* The document **must** use utf8 encoding.
 
 
 ## Document Specification


### PR DESCRIPTION
Fixes #77 

### What was wrong

Two lockfiles with identical content can easily end up hashing to a different value due to differences in whitespace used when serializing the JSON.

### How was it fixed

Define a *strict* definition of serialization which is tightly packed with sorted keys and utf8 encoded.