### PR TITLE
Add BIP link and change package name length from 214 to 256

### DIFF
--- a/release-lockfile.spec.md
+++ b/release-lockfile.spec.md
@@ -151,7 +151,7 @@ way.
 
 ### Package Name
 
-A string matching the regular expression `[a-zA-Z][-_a-zA-Z0-9]{0,213}`
+A string matching the regular expression `[a-zA-Z][-_a-zA-Z0-9]{0,255}`
 
 
 #### Content Addressable URI
@@ -167,6 +167,7 @@ It is **recommended** that tools support IPFS and Swarm.
 #### Chain Definition 
 
 This definition originates from BIP122 URI
+See BIP122 definition [here](https://github.com/bitcoin/bips/blob/master/bip-0122.mediawiki).
 
 An URI in the format `blockchain://<chain_id>/block/<block_hash>`
 

--- a/spec/release-lockfile.spec.json
+++ b/spec/release-lockfile.spec.json
@@ -17,7 +17,7 @@
     "package_name": {
       "title": "The name of the package that this release is for",
       "type": "string",
-      "pattern": "^[a-z][-a-z0-9]{0,213}$"
+      "pattern": "^[a-z][-a-z0-9]{0,255}$"
     },
     "meta": {
       "$ref": "#/definitions/PackageMeta"
@@ -70,7 +70,7 @@
       "title": "Build Dependencies",
       "type": "object",
       "patternProperties": {
-        "^[a-z][-a-z0-9]{0,213}$": {
+        "^[a-z][-a-z0-9]{0,255}$": {
           "$ref": "#/definitions/ContentURI"
         }
       }
@@ -153,7 +153,7 @@
         "contract_type": {
           "title": "The contract type of this contract instance",
           "type": "string",
-          "pattern": "^(?:[a-z][-a-z0-9]{0,213}\\:)?[a-zA-Z][-a-zA-Z0-9_]{0,255}(?:\\[[-a-zA-Z0-9]{1,256}\\])?$"
+          "pattern": "^(?:[a-z][-a-z0-9]{0,255}\\:)?[a-zA-Z][-a-zA-Z0-9_]{0,255}(?:\\[[-a-zA-Z0-9]{1,256}\\])?$"
         },
         "address": {
           "$ref": "#/definitions/Address"
@@ -211,7 +211,7 @@
     "PackageContractInstanceName": {
       "title": "The path to a deployed contract instance somewhere down the dependency tree",
       "type": "string",
-      "pattern": "^([a-z][-a-z0-9]{0,213}\\:)+[a-zA-Z][a-zA-Z0-9_]{0,255}$"
+      "pattern": "^([a-z][-a-z0-9]{0,255}\\:)+[a-zA-Z][a-zA-Z0-9_]{0,255}$"
     },
     "CompilerInformation": {
       "title": "Information about the software that was used to compile a contract type or instance",


### PR DESCRIPTION
Makes a couple changes that were suggested in the discussion of #72. Should make #72 ready to merge. 
- Add link to BIP 122 definition
- Update package name length from 214 to 256