### PR TITLE
Update title of spec document

### DIFF
--- a/spec/package.spec.json
+++ b/spec/package.spec.json
@@ -1,5 +1,5 @@
 {
-  "title": "Package Specification",
+  "title": "EthPM Manifest Specification",
   "type": "object",
   "required": [
     "manifest_version",


### PR DESCRIPTION
Since we're trying to use the "manifest" term more widely, this change seems appropriate.