### PR TITLE
Use prerelease tag for formal spec link

### DIFF
--- a/docs/source/package-spec.rst
+++ b/docs/source/package-spec.rst
@@ -90,7 +90,7 @@ included. Custom fields **should** be prefixed with ``x-`` to prevent
 name collisions with future versions of the specification.
 
   :See Also: Formalized (`JSON-Schema <http://json-schema.org>`_) version of
-    this specification: `package.spec.json <https://github.com/ethpm/ethpm-spec/tree/v2.0.0/spec/package.spec.json>`_
+    this specification: `package.spec.json <https://github.com/ethpm/ethpm-spec/tree/v2.0.0-prerelease.0/spec/package.spec.json>`_
   :Jump To: `Definitions`_
 
 .. _manifest-version:


### PR DESCRIPTION
#119 

The natural language specification links to the JSON-Schema via a literal GitHub tag.

Update link to use `v2.0.0-prerelease.0`, reserving `v2.0.0` for when EIP-1123 gets finalized.

Preview: https://ethpm.github.io/ethpm-spec/contrib/ethpm/fix-link/package-spec.html#document-specification