### PR TITLE
Use `description` instead of `title`

### DIFF
--- a/spec/package.spec.json
+++ b/spec/package.spec.json
@@ -1,5 +1,6 @@
 {
-  "title": "EthPM Manifest Specification",
+  "title": "Package Manifest",
+  "description": "EthPM Manifest Specification",
   "type": "object",
   "required": [
     "manifest_version",
@@ -10,12 +11,14 @@
   "properties": {
     "manifest_version": {
       "type": "string",
-      "title": "EthPM Manifest Version",
+      "title": "Manifest Version",
+      "description": "EthPM Manifest Version",
       "default": "2",
       "enum": ["2"]
     },
     "package_name": {
-      "title": "The name of the package that this release is for",
+      "title": "Package Name",
+      "description": "The name of the package that this release is for",
       "type": "string",
       "pattern": "^[a-z][-a-z0-9]{0,255}$"
     },
@@ -44,7 +47,8 @@
       }
     },
     "contract_types": {
-      "title": "The contract types included in this release",
+      "title": "Contract Types",
+      "description": "The contract types included in this release",
       "type": "object",
       "patternProperties": {
         "[a-zA-Z][-a-zA-Z0-9_]{0,255}(?:\\[[-a-zA-Z0-9]{1,256}\\])?$": {
@@ -53,7 +57,8 @@
       }
     },
     "deployments": {
-      "title": "The deployed contract instances in this release",
+      "title": "Deployments",
+      "description": "The deployed contract instances in this release",
       "type": "object",
       "patternProperties": {
         "^blockchain\\://[0-9a-zA-Z]{64}/block/[0-9a-zA-Z]{64}$": {
@@ -78,33 +83,39 @@
   },
   "definitions": {
     "PackageMeta": {
-      "title": "Metadata about the package",
+      "title": "Package Meta",
+      "description": "Metadata about the package",
       "type": "object",
       "properties": {
         "authors": {
-          "title": "Package authors",
+          "title": "Authors",
+          "description": "Authors of this package",
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "license": {
-          "title": "The license that this package and it's source are released under",
+          "title": "License",
+          "description": "The license that this package and it's source are released under",
           "type": "string"
         },
         "description": {
-          "title": "Description of this package",
+          "title": "Description",
+          "description": "Description of this package",
           "type": "string"
         },
         "keywords": {
-          "title": "Keywords that apply to this package",
+          "title": "Keywords",
+          "description": "Keywords that apply to this package",
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "links": {
-          "title": "URIs for resources related to this package",
+          "title": "Links",
+          "descriptions": "URIs for resources related to this package",
           "type": "object",
           "additionalProperties": {
             "type": "string",
@@ -114,11 +125,13 @@
       }
     },
     "ContractType": {
-      "title": "Data for a contract type included in this package",
+      "title": "Contract Type",
+      "description": "Data for a contract type included in this package",
       "type": "object",
       "properties":{
         "contract_name": {
-          "title": "The name for this contract type as found in the project source code.",
+          "title": "Contract Name",
+          "description": "The name for this contract type as found in the project source code.",
           "type": "string",
           "pattern": "[a-zA-Z][a-zA-Z0-9_]{0,255}"
         },
@@ -129,11 +142,13 @@
           "$ref": "#/definitions/BytecodeObject"
         },
         "abi": {
-          "title": "The ABI for this contract type",
+          "title": "ABI",
+          "description": "The ABI for this contract type",
           "type": "array"
         },
         "natspec": {
-          "title": "The combined user-doc and dev-doc for this contract",
+          "title": "NatSpec",
+          "description": "The combined user-doc and dev-doc for this contract",
           "type": "object"
         },
         "compiler": {
@@ -142,14 +157,16 @@
       }
     },
     "ContractInstance": {
-      "title": "Data for a deployed instance of a contract",
+      "title": "Contract Instance",
+      "description": "Data for a deployed instance of a contract",
       "type": "object",
       "required": [
         "contract_type"
       ],
       "properties": {
         "contract_type": {
-          "title": "The contract type of this contract instance",
+          "title": "Contract Type",
+          "description": "The contract type of this contract instance",
           "type": "string",
           "pattern": "^(?:[a-z][-a-z0-9]{0,255}\\:)?[a-zA-Z][-a-zA-Z0-9_]{0,255}(?:\\[[-a-zA-Z0-9]{1,256}\\])?$"
         },
@@ -169,7 +186,8 @@
           "$ref": "#/definitions/CompilerInformation"
         },
         "link_dependencies": {
-          "title": "The values for the link references found within this contract instances runtime bytecode",
+          "title": "Link Dependencies",
+          "description": "The values for the link references found within this contract instances runtime bytecode",
           "type": "array",
           "items": {
             "$ref": "#/definitions/LinkValue"
@@ -184,7 +202,7 @@
       "pattern": "^0x([0-9a-fA-F]{2})*$"
     },
     "BytecodeObject": {
-      "title": "Contract bytecode",
+      "title": "Contract Bytecode",
       "type": "object",
       "anyOf": [
         {"required": ["bytecode"]},
@@ -209,7 +227,8 @@
       }
     },
     "LinkReference": {
-      "title": "A defined location in some bytecode which requires linking",
+      "title": "Link Reference",
+      "description": "A defined location in some bytecode which requires linking",
       "type": "object",
       "required": [
         "offsets",
@@ -234,7 +253,8 @@
       }
     },
     "LinkValue": {
-      "title": "A value for an individual link reference in a contract's bytecode",
+      "title": "Link Value",
+      "description": "A value for an individual link reference in a contract's bytecode",
       "type": "object",
       "required": [
         "offsets",
@@ -250,11 +270,11 @@
           }
         },
         "type": {
-          "title": "The type of link value",
+          "description": "The type of link value",
           "type": "string"
         },
         "value": {
-          "title": "The value for the link reference"
+          "description": "The value for the link reference"
         }
       },
       "oneOf": [{
@@ -286,17 +306,20 @@
       "pattern": "^[a-zA-Z][a-zA-Z0-9_]{0,255}$"
     },
     "ContractInstanceName": {
-      "title": "The name of the deployed contract instance",
+      "title": "Contract Instance Name",
+      "description": "The name of the deployed contract instance",
       "type": "string",
       "pattern": "^[a-zA-Z][a-zA-Z0-9_]{0,255}$"
     },
     "PackageContractInstanceName": {
-      "title": "The path to a deployed contract instance somewhere down the dependency tree",
+      "title": "Package Contract Instance Name",
+      "description": "The path to a deployed contract instance somewhere down the dependency tree",
       "type": "string",
       "pattern": "^([a-z][-a-z0-9]{0,255}\\:)+[a-zA-Z][a-zA-Z0-9_]{0,255}$"
     },
     "CompilerInformation": {
-      "title": "Information about the software that was used to compile a contract type or instance",
+      "title": "Compiler Information",
+      "description": "Information about the software that was used to compile a contract type or instance",
       "type": "object",
       "required": [
         "name",
@@ -304,42 +327,46 @@
       ],
       "properties": {
         "name": {
-          "title": "The name of the compiler",
+          "description": "The name of the compiler",
           "type": "string"
         },
         "version": {
-          "title": "The version string for the compiler",
+          "description": "The version string for the compiler",
           "type": "string"
         },
         "settings": {
-          "title": "The settings used for compilation",
+          "description": "The settings used for compilation",
           "type": "object"
         }
       }
     },
     "Address": {
-      "title": "An Ethereum address",
+      "title": "Address",
+      "description": "An Ethereum address",
       "allOf": [
         { "$ref": "#/definitions/ByteString" },
         { "minLength": 42, "maxLength": 42 }
       ]
     },
     "TransactionHash": {
-      "title": "An Ethereum transaction hash",
+      "title": "Transaction Hash",
+      "description": "An Ethereum transaction hash",
       "allOf": [
         { "$ref": "#/definitions/ByteString" },
         { "minLength": 66, "maxLength": 66 }
       ]
     },
     "BlockHash": {
-      "title": "An Ethereum block hash",
+      "title": "Block Hash",
+      "description": "An Ethereum block hash",
       "allOf": [
         { "$ref": "#/definitions/ByteString" },
         { "minLength": 66, "maxLength": 66 }
       ]
     },
     "ContentURI": {
-      "title": "An content addressable URI",
+      "title": "Content URI",
+      "description": "An content addressable URI",
       "type": "string",
       "format": "uri"
     }


### PR DESCRIPTION
Since most `title` properties serve as descriptions.

For top-level definitions, provide `title` with values that can serve as a variable name