### PR TITLE
Add first-class Deployment definition

### DIFF
--- a/spec/package.spec.json
+++ b/spec/package.spec.json
@@ -62,12 +62,7 @@
       "type": "object",
       "patternProperties": {
         "^blockchain\\://[0-9a-zA-Z]{64}/block/[0-9a-zA-Z]{64}$": {
-          "type": "object",
-          "patternProperties": {
-            "^[a-zA-Z][a-zA-Z0-9_]{0,255}$": {
-              "$ref": "#/definitions/ContractInstance"
-            }
-          }
+          "$ref": "#/definitions/Deployment"
         }
       }
     },
@@ -310,6 +305,15 @@
       "description": "The name of the deployed contract instance",
       "type": "string",
       "pattern": "^[a-zA-Z][a-zA-Z0-9_]{0,255}$"
+    },
+    "Deployment": {
+      "title": "Deployment",
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z][a-zA-Z0-9_]{0,255}$": {
+          "$ref": "#/definitions/ContractInstance"
+        }
+      }
     },
     "PackageContractInstanceName": {
       "title": "Package Contract Instance Name",


### PR DESCRIPTION
To improve schema accessibility for tools that do schema processing, etc.

This arose from using `json-schema-to-typescript`; reducing nesting and giving things names improves types generation.