### PR TITLE
Update regex in package spec, fix broken link

### DIFF
--- a/docs/source/package-spec.rst
+++ b/docs/source/package-spec.rst
@@ -209,7 +209,7 @@ Deployments: ``deployments``
 The ``deployments`` field holds the information for the chains on which
 this release has |ContractInstances| as well as the |ContractTypes|
 and other deployment details for those deployed contract instances.
-The set of chains defined by the `BIP122 URI <#bip122-uris>` keys for this
+The set of chains defined by the :ref:`BIP122 URI<bip122-bip122-1>` keys for this
 object **must** be unique. There cannot be two different URI keys in a deployments
 field representing the same blockchain.
 
@@ -747,6 +747,8 @@ to the `Compiler Input and Output Description <http://solidity.readthedocs.io/en
   :Type: Object
 
 ----
+
+.. _bip122-bip122-1:
 
 BIP122 URIs
 ~~~~~~~~~~~

--- a/docs/source/package-spec.rst
+++ b/docs/source/package-spec.rst
@@ -117,7 +117,7 @@ names **must** not exceed 255 characters in length.
   :Key: ``package_name``
   :Type: String
   :Format: **must** match the regular expression
-    ``^[a-zA-Z][a-zA-Z0-9_]{0,255}$``
+    ``^[a-z][a-z0-9_-]{0,255}$``
 
 ----
 


### PR DESCRIPTION
* Modified package spec regex string to be consistent with human readable spec, closes #131 
* Fixed broken link to bip122 section

I just tripped over the regex inconsistency. After copypasting from the docs into my implementation I was unable to import packages, as many names contain a `-`.