### PR TITLE
Add best practices to v3 spec

### DIFF
--- a/docs/source/v3-package-spec.rst
+++ b/docs/source/v3-package-spec.rst
@@ -74,6 +74,16 @@ following serialization rules.
 
 ----
 
+Best Practices
+--------------
+
+The EthPM specification is designed to be as flexible as possible, adapting to many
+different use cases. As a result, it places few restrictions on what fields are required
+in a single package. However, it is recommended that package authors include all available
+contract assets in a package to make it as useful as possible.
+
+----
+
 Document Specification
 ----------------------
 


### PR DESCRIPTION
Add a little blurb to start off a `best practices` section of the docs.