### PR TITLE
Update travis python version to 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - 3.5
+  - 3.8
 install:
   - sudo apt-get install graphviz asciidoc pandoc
   - pip install -r requirements.txt


### PR DESCRIPTION
Failing test in ci due to outdated python version used by travis.