### PR TITLE
Enforce top-level `manifest_version` field is illegal

### DIFF
--- a/docs/source/v3-package-spec.rst
+++ b/docs/source/v3-package-spec.rst
@@ -71,6 +71,8 @@ following serialization rules.
 -  Duplicate keys in the same object are invalid.
 -  The document **must** use `UTF-8 <https://en.wikipedia.org/wiki/UTF-8>`_ encoding.
 -  The document **must** not have a trailing newline.
+-  To ensure backwards compatibility, `manifest_version` is a forbidden
+   top-level key.
 
 ----
 

--- a/spec/v3.spec.json
+++ b/spec/v3.spec.json
@@ -6,6 +6,9 @@
     "manifest"
   ],
   "version": "3",
+  "not": {
+    "required": ["manifest_version"]
+  },
   "properties": {
     "manifest": {
       "type": "string",

--- a/tests/fixtures/schemaValidation/base/invalid/invalidManifestVersionField.json
+++ b/tests/fixtures/schemaValidation/base/invalid/invalidManifestVersionField.json
@@ -1,0 +1,9 @@
+{
+    "package": "{\"manifest\":\"ethpm/3\",\"manifest_version\":\"2\"}",
+    "testCase": "invalid",
+    "errorInfo": {
+        "errorCode": "N0003",
+        "errorPointer": "/",
+        "reason": "['manifest_version']} is not allowed"
+    }
+}


### PR DESCRIPTION
V2 defined the manifest version in a `"manifest_version"` field. V3 defines the manifest version in a `"manifest"` field. In order to increase the delineation between V2 & V3 manifests, it would be useful to make it illegal to use a top-level key of `"manifest_version"` in V3 manifests. While it's unlikely that users would add a user-defined field of `"manifest_version"` to a V3 manifest, explicitly forbidding this field will make it easier for machines to distinguish b/w V2 & V3 manifests. 