### PR TITLE
Update automatically generated package type to v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.0",
   "description": "Ethereum Package Manager Specifications",
   "scripts": {
-    "prepare": "json2ts -i ./spec/package.spec.json -o ./index.d.ts"
+    "prepare": "json2ts -i ./spec/v3.spec.json -o ./index.d.ts"
   },
   "files": [
     "spec",


### PR DESCRIPTION
`jsonschema2typescript` automatically generates typescript types from the manifest spec, and this needed to be updated to use the v3 json schema spec.